### PR TITLE
Add empty block option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ const html = convertToHTML({
     blockToHTML: {
         'PARAGRAPH': {
             start: '<p>',
-            end: '</p>'
+            end: '</p>',
+            empty: '<br>'
         }
     },
     entityToHTML: (entity, originalText) => {
@@ -48,14 +49,15 @@ const html = compose(
 ```
 
 `styleToHTML` and `blockToHtml` are objects keyed by `DraftInlineStyle` and `DraftBlockType` respectively and map
-to beginning and ending tags to use. Both extend upon defaults that support the default style and block types. If no additional functionality is necessary `convertToHTML` can be invoked with just a `ContentState` to serialize using just the default Draft functionality. `convertToHTML` can be passed as an argument to a plugin to modularly augment its functionality.
+to beginning and ending tags to use. Blocks also have an optional `empty` property to handle alternative behavior for empty blocks. Both extend upon defaults that support the default style and block types. If no additional functionality is necessary `convertToHTML` can be invoked with just a `ContentState` to serialize using just the default Draft functionality. `convertToHTML` can be passed as an argument to a plugin to modularly augment its functionality.
 
 **Type info:**
 ```
 type TagObject = {
     [key: string]: {
         start: string,
-        end: string
+        end: string,
+        empty?: string
     }
 }
 

--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -76,7 +76,12 @@ const convertToHTML = ({
       ),
       styleToHTML
     );
-    const html = blockHTML[type].start + innerHTML + blockHTML[type].end;
+
+    let html = blockHTML[type].start + innerHTML + blockHTML[type].end;
+    if (innerHTML.length === 0 && blockHTML[type].hasOwnProperty('empty')) {
+      html = blockHTML[type].empty;
+    }
+
     return closeNestTags + openNestTags + html;
   }).join('');
 

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -47,6 +47,27 @@ describe('convertToHTML', () => {
     expect(result).toBe('<p></p>');
   });
 
+  it('uses empty state for an empty block', () => {
+    const contentState = buildContentState([
+      {
+        type: 'unstyled',
+        text: ''
+      }
+    ]);
+
+    const result = convertToHTML({
+      blockToHTML: {
+        'unstyled': {
+          start: '<p>',
+          end: '</p>',
+          empty: '<br>'
+        }
+      }
+    })(contentState);
+
+    expect(result).toBe('<br>');
+  });
+
   it('applies inline styles to a block', () => {
     const contentState = buildContentState([
       {


### PR DESCRIPTION
@gusvargas @frandias

when putting HTML output with empty blocks directly in the DOM empty `<p>` tags don't render out as space. To fix this (and any general special behavior) adding an empty state to block configuration.
