### PR TITLE
Allow passing in convertToRaw function to convertToHTML

### DIFF
--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -1,6 +1,6 @@
 // import Immutable from 'immutable'; // eslint-disable-line no-unused-vars
 import invariant from 'invariant';
-import {convertToRaw} from 'draft-js';
+import { convertToRaw as draftConvertToRaw } from 'draft-js';
 import encodeBlock from './encodeBlock';
 import convertEntity from './convertEntity';
 import blockInnerHTML from './blockInnerHTML';
@@ -18,7 +18,8 @@ const defaultEntityToHTML = (entity, originalText) => {
 const convertToHTML = ({
   styleToHTML = {},
   blockToHTML = {},
-  entityToHTML = defaultEntityToHTML
+  entityToHTML = defaultEntityToHTML,
+  convertToRaw = draftConvertToRaw,
 }) => (contentState) => {
   invariant(
     contentState !== null && contentState !== undefined,

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -284,4 +284,40 @@ describe('convertToHTML', () => {
     }})(contentState);
     expect(result).toBe('<p>t<a>e&lt;&amp;&gt;s</a><strong>t</strong></p>')
   });
+
+  it('uses the optional convertToRaw function', () => {
+    const mockRaw = {
+      blocks: [
+        {
+          depth: 0,
+          entityRanges: [{key: 0, length: 6, offset: 5}],
+          inlineEntityRanges: [],
+          inlineStyleRanges: [],
+          key: '2er96',
+          text: 'Test entity',
+          type: 'unstyled'
+        }
+      ],
+      entityMap: {
+        0: {
+          data: {
+            id: 'test-entity-id'
+          },
+          mutability: 'IMMUTABLE',
+          type: 'VARIABLE'
+        }
+      }
+    };
+
+    const result = convertToHTML({
+      entityToHTML: (entity, originalText) => {
+        if (entity.type === 'VARIABLE') {
+          return `<variable data-id="${entity.data.id}">${originalText}</variable>`;
+        }
+        return originalText;
+      },
+      convertToRaw: (contentState) => mockRaw
+    })({});
+    expect(result).toEqual('<p>Test <variable data-id="test-entity-id">entity</variable></p>')
+  });
 });

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -13,7 +13,7 @@ module.exports = {
     libraryTarget: 'umd'
   },
   externals: {
-    'draft-js': 'Draft',
+    'draft-js': 'DraftPublic',
     'immutable': 'Immutable'
   }
 };


### PR DESCRIPTION
Because Entity state is global to the instance of Draft, if a user loads
entities into their Draft and then tries to call convertToHTML on that
content state, our Draft's instance won't have those Entities, and our
convertToRaw will blow up.

So we need to allow users to pass in their own convertToRaw, which will
access their Entity state.