### PR TITLE
Use checkBlockType to determine block type of newline chunk

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -405,7 +405,9 @@ function genFragment(
       blockTags.indexOf(nodeName) >= 0 &&
       inBlock
     ) {
-      chunk = joinChunks(chunk, getSoftNewlineChunk(getBlockTypeForTag(nodeName, lastList), depth));
+      const newBlockType = checkBlockType(nodeName, node, lastList, inBlock) || getBlockTypeForTag(nodeName, lastList);
+
+      chunk = joinChunks(chunk, getSoftNewlineChunk(newBlockType, depth));
     }
     if (sibling) {
       nodeName = sibling.nodeName.toLowerCase();

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -13,6 +13,10 @@ describe('convertFromHTML', () => {
   const toContentState = html => {
     return convertFromHTML({
       htmlToBlock: (nodeName, node, lastList, inBlock) => {
+        if ((nodeName === 'p' || nodeName === 'div') && inBlock === 'blockquote') {
+          return 'blockquote';
+        }
+
         if (nodeName === 'figure' && node.firstChild.nodeName === 'IMG' || (nodeName === 'img' && inBlock !== 'atomic')) {
           return 'atomic';
         }
@@ -316,5 +320,12 @@ describe('convertFromHTML', () => {
     expect(contentState.getPlainText()).toBe('test&');
     const resultHTML = convertToHTML(contentState);
     expect(resultHTML).toBe(html);
+  });
+  it('handles nested blocks in blockquote', () => {
+    const html = '<blockquote><p>test</p><p>test</p></blockquote>';
+    const contentState = toContentState(html);
+    contentState.getBlocksAsArray().forEach((block) => {
+      expect(block.getType()).toBe('blockquote');
+    });
   });
 });


### PR DESCRIPTION
Helps to fix #6 

When handling nested block elements, use `checkBlockType` to allow custom behavior for what block type should be assigned when nested in other blocks, e.g. matching all `p` tags within a `blockquote` tag as type `blockquote`.