### PR TITLE
convertFromHTML: fix nested default blocks

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -418,7 +418,7 @@ function genFragment(
       blockTags.indexOf(nodeName) >= 0 &&
       inBlock
     ) {
-      const newBlockInfo = checkBlockType(nodeName, node, lastList, inBlock);
+      const newBlockInfo = checkBlockType(nodeName, node, lastList, inBlock) || {};
 
       let newBlockType;
       let newBlockData;

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -214,7 +214,6 @@ describe('convertFromHTML', () => {
     expect(contentState.getBlocksAsArray().length).toBe(3);
     expect(convertToHTML(contentState)).toBe('<p>one</p><p></p><p>two</p>');
   });
-
   it('handles brs at top level', () => {
     const html = '<p>one</p><br/><p>three</p>';
     const contentState = toContentState(html);
@@ -348,5 +347,12 @@ describe('convertFromHTML', () => {
     expect(block.getType()).toBe('atomic');
     expect(block.getData().get('atomicType')).toBe('image');
     expect(block.getData().get('src')).toBe('testimage');
+  });
+
+  it('handles undefined nested block types', () => {
+    const html = `<div><div>This won't work, first line</div></div>`;
+    const contentState = toContentState(html);
+    const block = contentState.getBlocksAsArray()[0];
+    expect(block.getType()).toBe('unstyled');
   });
 });

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -214,6 +214,7 @@ describe('convertFromHTML', () => {
     expect(contentState.getBlocksAsArray().length).toBe(3);
     expect(convertToHTML(contentState)).toBe('<p>one</p><p></p><p>two</p>');
   });
+
   it('handles brs at top level', () => {
     const html = '<p>one</p><br/><p>three</p>';
     const contentState = toContentState(html);


### PR DESCRIPTION
I forgot to make the same undefined check in both places where we handle the new block metadata in #9 to default to an empty object 😶 