### PR TITLE
fix HTML escaping multiple characters along with other entities/styles

### DIFF
--- a/src/encodeBlock.js
+++ b/src/encodeBlock.js
@@ -22,10 +22,11 @@ export default(block) => {
 
     if (ENTITY_MAP[char] !== undefined) {
       const encoded = ENTITY_MAP[char];
+      const resultIndex = resultText.length;
       resultText += encoded;
 
       const updateForChar = (mutation) => {
-        return updateMutation(mutation, index, char.length, encoded.length);
+        return updateMutation(mutation, resultIndex, char.length, encoded.length);
       };
 
       entities = entities.map(updateForChar);

--- a/test/spec/blockEntities.js
+++ b/test/spec/blockEntities.js
@@ -325,20 +325,20 @@ describe('blockEntities', () => {
         type: 'testEntity',
         mutability: 'IMMUTABLE',
         data: {
-          test: '{{ contact.company }}'
+          test: '{{ entity }}'
         }
       }
     };
 
     const rawBlock = buildRawBlock(
-      `other'''''''text contact\'s othertext`,
+      `other'''''''text test\'s othertext`,
       entityMap,
       [],
       [
         {
           key: 0,
           offset: 17,
-          length: 7
+          length: 4
         }
       ]
     );
@@ -359,6 +359,6 @@ describe('blockEntities', () => {
       )
     );
 
-    expect(result).toBe('other&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;text {{ contact.company }}&#x27;s othertext');
+    expect(result).toBe('other&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;text {{ entity }}&#x27;s othertext');
   });
 });

--- a/test/spec/blockEntities.js
+++ b/test/spec/blockEntities.js
@@ -1,5 +1,6 @@
 import blockEntities from '../../src/blockEntities';
 import blockInlineStyles from '../../src/blockInlineStyles';
+import encodeBlock from '../../src/encodeBlock';
 import {convertFromRaw, convertToRaw} from 'draft-js';
 import {Map} from 'immutable';
 
@@ -316,5 +317,48 @@ describe('blockEntities', () => {
       )
     );
     expect(result).toBe('abcde <strong>abcde</strong>');
+  });
+
+  it('adjusts styles around the entity range', () => {
+    const entityMap = {
+      0: {
+        type: 'testEntity',
+        mutability: 'IMMUTABLE',
+        data: {
+          test: '{{ contact.company }}'
+        }
+      }
+    };
+
+    const rawBlock = buildRawBlock(
+      `other'''''''text contact\'s othertext`,
+      entityMap,
+      [],
+      [
+        {
+          key: 0,
+          offset: 17,
+          length: 7
+        }
+      ]
+    );
+
+    const result = blockInlineStyles(
+      blockEntities(
+        encodeBlock(
+          rawBlock
+        ),
+        entityMap,
+        (entity, originalText) => {
+          if (entity.type === 'testEntity') {
+            return entity.data.test;
+          }
+
+          return originalText;
+        }
+      )
+    );
+
+    expect(result).toBe('other&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;&#x27;text {{ contact.company }}&#x27;s othertext');
   });
 });


### PR DESCRIPTION
fix issue with HTML escaping multiple characters when updating other mutations (entities, styles) using an index that hasn't been updated to account for previous HTML escaping changes.

e.g. if two quotes are each replaced with `&quot;` the second must update further mutations based on its new position after the first quote was already replaced with a longer string.