### PR TITLE
Remove built-in link conversion from convertFromHTML

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -387,14 +387,6 @@ function genFragment(
   while (child) {
     entityId = checkEntityNode(nodeName, child);
 
-    if (!entityId) {
-      // Link plugin handles this, but keep this here in the interest of preserving links when not using it
-      if (nodeName === 'a' && child.href && hasValidLinkText(child)) {
-        href = child.href;
-        entityId = Entity.create('LINK', 'MUTABLE', {url: href});
-      }
-    }
-
     newChunk = genFragment(
       child,
       inlineStyle,

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -232,15 +232,6 @@ function containsSemanticBlockMarkup(html) {
   return blockTags.some(tag => html.indexOf('<' + tag) !== -1);
 }
 
-function hasValidLinkText(link) {
-  invariant(
-    link instanceof HTMLAnchorElement,
-    'Link must be an HTMLAnchorElement.'
-  );
-  var protocol = link.protocol;
-  return protocol === 'http:' || protocol === 'https:';
-}
-
 function genFragment(
   node,
   inlineStyle,

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -44,6 +44,11 @@ describe('convertFromHTML', () => {
         }
       },
       htmlToEntity: (nodeName, node) => {
+        if (nodeName === 'a' && node.href) {
+          const href = node.href;
+          return Entity.create('LINK', 'MUTABLE', {url: href});
+        }
+
         if (nodeName === 'testnode') {
           return Entity.create('TEST', 'IMMUTABLE', {
             testAttr: node.getAttribute('test-attr')


### PR DESCRIPTION
This can cause issues with other links within atomic blocks since it doesn't have the same checks to prevent issues with creating text via [this temporary hack](https://github.com/HubSpot/draft-convert/blob/master/src/convertFromHTML.js#L371-L378). This could be just made to watch out for that but it feels like something that shouldn't be in the project, since links aren't natively rendered by Draft.