### PR TITLE
Add failing test for overlapping styles in entity.

### DIFF
--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -316,4 +316,55 @@ describe('convertToHTML', () => {
 
     expect(result).toBe('<customtag attribute="value">test</customtag>');
   });
+
+  it('combines styles and entities without overlap', () => {
+      const contentState = buildContentState([
+          {
+              type: 'unstyled',
+              text: 'overlapping styles in entity',
+              styleRanges: [
+                  {
+                      offset: 0,
+                      length: 14,
+                      style: 'BOLD',
+                  },
+                  {
+                      offset: 14,
+                      length: 14,
+                      style: 'ITALIC',
+                  }
+              ],
+              entityRanges: [
+                  {
+                      key: 0,
+                      offset: 0,
+                      lenth: 28,
+                  }
+              ],
+          },
+      ], {
+          0: {
+              type: 'LINK',
+              mutability: 'IMMUTABLE',
+              data: {
+                  href: 'http://google.com',
+              },
+          }
+      });
+
+      const result = convertToHTML({
+          entityToHTML: (entity, originalText) => {
+              if (entity.type === 'LINK') {
+                  const {data} = entity;
+
+                  return `<a href="${data.href}">${originalText}</a>`;
+              }
+
+              return originalText;
+          }
+      })(contentState);
+
+
+      expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
+  });
 });


### PR DESCRIPTION
I've been noticing a bug when converting an entity that also contains styles. The intended result should be:

``` html
<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>
```

But instead it outputs as:

``` html
<p><strong><a href="http:</strong><em>//google.com"></em>overlapping styles in entity</a></p>
```

I've trailed down the issue to the fact that the `length` and `offset` of the style ranges no longer match after an entity has been converted.

I'd happily change this myself if pointed in the right direction.
