### PR TITLE
Add React & ReactDOM to externals

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -14,6 +14,9 @@ module.exports = {
   },
   externals: {
     'draft-js': 'Draft',
-    'immutable': 'Immutable'
+    'immutable': 'Immutable',
+    'react': 'React',
+    'react-dom': 'ReactDOM',
+    'react-dom/server': 'ReactDOMServer'
   }
 };


### PR DESCRIPTION
1.3.0 imports `react` and `react-dom/server`, but I missed adding them to externals to keep them out of the webpack output 😬 