### PR TITLE
Fix block conversion from HTML to only include defined elements

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -154,12 +154,11 @@ function getBlockTypeForTag(tag, lastList) {
       return 'blockquote';
     case 'pre':
       return 'code-block';
-    case 'ul':
-      return null;
-    case 'ol':
-      return null;
-    default:
+    case 'div':
+    case 'p':
       return 'unstyled';
+    default:
+      return null;
   }
 }
 


### PR DESCRIPTION
Defaulting to `unstyled` was a bad idea, since any inline element would then count as an unstyled block. Defining `div` and `p` should complete the set of supported block tags out of the box, with any custom functionality able to iterate on top of it with `htmlToBlock` middleware