### PR TITLE
add npm/license badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # **draft-convert**
 
+[![npm version](https://badge.fury.io/js/draft-convert.svg)](https://www.npmjs.com/package/draft-convert) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 *Extensibly serialize & deserialize [**Draft.js**](http://draftjs.org/) content with HTML*
 
 *See [**draft-extend**](http://github.com/HubSpot/draft-extend) for more on how to use draft-convert with plugins*


### PR DESCRIPTION
![screen shot 2016-12-15 at 11 02 11 pm](https://cloud.githubusercontent.com/assets/3171252/21252197/89ebd760-c31a-11e6-87db-a1ef2c1815c2.png)

makes it easier to get to npm (since there isn't a link in readme currently) 🎉  
