### PR TITLE
Fix version of immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^15.0.2"
   },
   "dependencies": {
-    "immutable": "^3.8.1",
+    "immutable": "~3.7.4",
     "invariant": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, please check this.

I think that version of `immutable` should be the same as `draft-js` .

ref: https://github.com/facebook/draft-js/blob/0.10-stable/package.json#L34
