### PR TITLE
Render block children

### DIFF
--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -99,7 +99,13 @@ const convertToHTML = ({
       getBlockHTML(block)
     );
 
-    let html = blockHTML.start + innerHTML + blockHTML.end;
+    let html;
+
+    if (typeof blockHTML === 'string') {
+      html = blockHTML;
+    } else {
+      html = blockHTML.start + innerHTML + blockHTML.end;
+    }
 
     if (innerHTML.length === 0 && blockHTML.hasOwnProperty('empty')) {
       if (React.isValidElement(blockHTML.empty)) {

--- a/src/util/getBlockTags.js
+++ b/src/util/getBlockTags.js
@@ -1,6 +1,11 @@
 import invariant from 'invariant';
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import splitReactElement from './splitReactElement';
+
+function hasChildren(element) {
+  return React.isValidElement(element) && React.Children.count(element.props.children) > 0;
+}
 
 export default function getBlockTags(blockHTML) {
   invariant(
@@ -9,6 +14,10 @@ export default function getBlockTags(blockHTML) {
   );
 
   if (React.isValidElement(blockHTML)) {
+    if (hasChildren(blockHTML)) {
+      return ReactDOMServer.renderToStaticMarkup(blockHTML);
+    }
+
     return splitReactElement(blockHTML);
   }
 

--- a/test/spec/getBlockTags.js
+++ b/test/spec/getBlockTags.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import getBlockTags from '../../src/util/getBlockTags';
+
+describe('getBlockTags', () => {
+  it('accepts a start/end pair object', () => {
+    const block = {
+      start: '<p>',
+      end: '</p>'
+    };
+
+    expect(getBlockTags(block)).toBe(block);
+  });
+
+  it('accepts an empty react element', () => {
+    const block = <p />;
+    const result = {
+      start: '<p>',
+      end: '</p>'
+    };
+    expect(getBlockTags(block)).toEqual(result);
+  });
+
+  it('accepts an empty react element with an empty option', () => {
+    const block = {
+      element: <p />,
+      empty: <br />
+    };
+    const result = {
+      start: '<p>',
+      end: '</p>',
+      empty: <br />
+    };
+    expect(getBlockTags(block)).toEqual(jasmine.objectContaining(result));
+  });
+
+  it('accepts a react element with children', () => {
+    const block = <p>asdf</p>;
+    const result = '<p>asdf</p>';
+    expect(getBlockTags(block)).toBe(result);
+  });
+});


### PR DESCRIPTION
A common block type conversion for an atomic block will include the wrapping tag as well as content within, e.g.: 

```javascript
return (
  <figure><img src={src} /></figure>
);
```

This PR allows children of the root React element in the returned value to be rendered along with the wrapping element if it exists. I also added some additional base tests for `getBlockTags`.

Empty React elements returned will continue to act as usual