### PR TITLE
omit whitespace in HTML input

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -279,6 +279,10 @@ function genFragment(
   // Base Case
   if (nodeName === '#text') {
     let text = node.textContent;
+    if (text.trim() === '' && inBlock === null) {
+      return getEmptyChunk();
+    }
+
     if (text.trim() === '' && inBlock !== 'code-block') {
       return getWhitespaceChunk(inEntity);
     }

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -539,4 +539,22 @@ describe('convertFromHTML', () => {
     const rawState = convertToRaw(contentState);
     expect(rawState.blocks[0].inlineStyleRanges[0].style).toBe('BOLD2');
   });
+
+  it('handles newlines in HTML source', () => {
+    const html = `<ul>
+        <li>To do 1</li>
+        <li>To do 2</li>
+      </ul>
+      <ol>
+        <li>To do 1</li>
+        <li>To do 2</li>
+      </ol>
+    `;
+
+    const contentState = toContentState(html);
+    const blocks = contentState.getBlocksAsArray();
+    expect(blocks.length).toBe(4);
+    expect(blocks.slice(0, 2).every(block => block.getType() === 'unordered-list-item')).toBe(true);
+    expect(blocks.slice(2, 4).every(block => block.getType() === 'ordered-list-item')).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes additional comments in #22 by @khrykin

Completely omits any whitespace outside of any identified block. Whitespace within blocks are useful and probably necessary to keep, especially in the case of atomic blocks that use entity data on a single space character.