### PR TITLE
Support ReactElement entity conversion for nested styles

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -1,6 +1,7 @@
 import updateMutation from './util/updateMutation';
 import rangeSort from './util/rangeSort';
 import getElementHTML from './util/getElementHTML';
+import getElementPrefix from './util/getElementPrefix';
 
 const converter = (entity = {}, originalText) => {
   return originalText;
@@ -30,10 +31,7 @@ export default (block, entityMap, entityConverter = converter) => {
       const converted = getElementHTML(entityHTML, originalText)
                         || originalText;
 
-      let prefixLength = 0;
-      if (typeof entityHTML === 'object') {
-        prefixLength = entityHTML.start ? entityHTML.start.length : 0;
-      }
+      const prefixLength = getElementPrefix(entityHTML);
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {

--- a/src/util/getElementPrefix.js
+++ b/src/util/getElementPrefix.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import splitReactElement from './splitReactElement';
+
+export default element => {
+  if (React.isValidElement(element) && React.Children.count(element.props.children) === 0) {
+    return splitReactElement(element).start.length;
+  }
+
+  if (typeof element === 'object') {
+    return element.start ? element.start.length : 0;
+  }
+
+  return 0;
+};

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -373,6 +373,56 @@ describe('convertToHTML', () => {
     expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
   });
 
+  it('combines styles and entities without overlap using react to conver to HTML', () => {
+    const contentState = buildContentState([
+      {
+        type: 'unstyled',
+        text: 'overlapping styles in entity',
+        styleRanges: [
+          {
+            offset: 0,
+            length: 14,
+            style: 'BOLD'
+          },
+          {
+            offset: 14,
+            length: 14,
+            style: 'ITALIC'
+          }
+        ],
+        entityRanges: [
+          {
+            key: 0,
+            offset: 0,
+            length: 28
+          }
+        ],
+      },
+    ], {
+      0: {
+        type: 'LINK',
+        mutability: 'IMMUTABLE',
+        data: {
+          href: 'http://google.com',
+        }
+      }
+    });
+
+    const result = convertToHTML({
+      entityToHTML: (entity, originalText) => {
+        if (entity.type === 'LINK') {
+          const { data } = entity;
+
+          return <a href={data.href} />;
+        }
+
+        return originalText;
+      }
+    })(contentState);
+
+    expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
+  });
+
   it('uses JSX for block HTML', () => {
     const contentState = buildContentState([
       {


### PR DESCRIPTION
follow-up to https://github.com/HubSpot/draft-convert/pull/43 - calculate entity prefixes for  `ReactElement`s in addition to `{ start, end }` HTML objects. Abstracted the logic out into a separate module as well and added a slightly modified test to describe this case.