### PR TITLE
Fix erroneous second argument to `checkBlockType`

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -428,7 +428,7 @@ function genFragment(
       && fragmentBlockTags.indexOf(nodeName) >= 0
       && inBlock
     ) {
-      const newBlockInfo = checkBlockType(nodeName, node, lastList, inBlock) || {};
+      const newBlockInfo = checkBlockType(nodeName, child, lastList, inBlock) || {};
 
       let newBlockType;
       let newBlockData;


### PR DESCRIPTION
Above `nodeName` correctly becomes `child.nodeName.toLowerCase()`, so the matching `child` should be passed instead of its parent.