### PR TITLE
Handle void HTML elements

### DIFF
--- a/src/util/splitReactElement.js
+++ b/src/util/splitReactElement.js
@@ -2,7 +2,29 @@ import invariant from 'invariant';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
+// see http://w3c.github.io/html/syntax.html#writing-html-documents-elements
+const VOID_TAGS = [
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr'
+];
+
 export default function splitReactElement(element) {
+  if (VOID_TAGS.indexOf(element.type) !== -1) {
+    return ReactDOMServer.renderToStaticMarkup(element);
+  }
+
   const tags = ReactDOMServer.renderToStaticMarkup(
     React.cloneElement(
       element,

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -483,4 +483,23 @@ describe('convertToHTML', () => {
 
     expect(html).toBe('<testelement>test</testelement>');
   });
+
+  it('allows void elements to be result of blockToHTML', () => {
+    const contentState = buildContentState([
+      {
+        type: 'image',
+        text: ''
+      }
+    ]);
+
+    const blockToHTML = (block) => {
+      if (block.type === 'image') {
+        return <img />;
+      }
+    };
+
+    const html = convertToHTML({ blockToHTML })(contentState);
+
+    expect(html).toBe('<img/>');
+  });
 });

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -488,11 +488,11 @@ describe('convertToHTML', () => {
     const contentState = buildContentState([
       {
         type: 'image',
-        text: ''
+        text: 'test'
       }
     ]);
 
-    const blockToHTML = (block) => {
+    const blockToHTML = block => {
       if (block.type === 'image') {
         return <img />;
       }


### PR DESCRIPTION
Fixes https://github.com/HubSpot/draft-convert/issues/30

Adds an exception list from [W3C](http://w3c.github.io/html/syntax.html#writing-html-documents-elements) and doesn't try to split those elements into `start` and `end` tags, instead just returning a single string.