### PR TITLE
Handle intersecting mutations

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -44,14 +44,16 @@ export default (block, entityMap, entityConverter = converter) => {
         return mutation;
       };
 
-      const updateLaterMutations = mutationList => mutationList.reduce((acc, mutation, mutationIndex) => {
-        const updatedMutation = updateLaterMutation(mutation, mutationIndex);
-        if (Array.isArray(updatedMutation)) {
-          return acc.concat(updatedMutation);
-        }
+      const updateLaterMutations = mutationList => mutationList.reduce(
+        (acc, mutation, mutationIndex) => {
+          const updatedMutation = updateLaterMutation(mutation, mutationIndex);
+          if (Array.isArray(updatedMutation)) {
+            return acc.concat(updatedMutation);
+          }
 
-        return acc.concat([updatedMutation]);
-      }, []);
+          return acc.concat([updatedMutation]);
+        }
+      , []);
 
       entities = updateLaterMutations(entities);
       styles = updateLaterMutations(styles);

--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -1,7 +1,7 @@
 import updateMutation from './util/updateMutation';
 import rangeSort from './util/rangeSort';
 import getElementHTML from './util/getElementHTML';
-import getElementPrefix from './util/getElementPrefix';
+import getElementTagLength from './util/getElementTagLength';
 
 const converter = (entity = {}, originalText) => {
   return originalText;
@@ -31,20 +31,30 @@ export default (block, entityMap, entityConverter = converter) => {
       const converted = getElementHTML(entityHTML, originalText)
                         || originalText;
 
-      const prefixLength = getElementPrefix(entityHTML);
+      const prefixLength = getElementTagLength(entityHTML, 'start');
+      const suffixLength = getElementTagLength(entityHTML, 'end');
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
           return updateMutation(
             mutation, entityRange.offset, entityRange.length,
-            converted.length, prefixLength
+            converted.length, prefixLength, suffixLength
           );
         }
         return mutation;
       };
 
-      entities = entities.map(updateLaterMutation);
-      styles = styles.map(updateLaterMutation);
+      const updateLaterMutations = mutationList => mutationList.reduce((acc, mutation, mutationIndex) => {
+        const updatedMutation = updateLaterMutation(mutation, mutationIndex);
+        if (Array.isArray(updatedMutation)) {
+          return acc.concat(updatedMutation);
+        }
+
+        return acc.concat([updatedMutation]);
+      }, []);
+
+      entities = updateLaterMutations(entities);
+      styles = updateLaterMutations(styles);
 
       resultText = resultText.substring(0, entityRange.offset)
                    + converted

--- a/src/encodeBlock.js
+++ b/src/encodeBlock.js
@@ -27,7 +27,7 @@ export default block => {
       resultText += encoded;
 
       const updateForChar = mutation => {
-        return updateMutation(mutation, resultIndex, char.length, encoded.length, 0);
+        return updateMutation(mutation, resultIndex, char.length, encoded.length, 0, 0);
       };
 
       entities = entities.map(updateForChar);

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import splitReactElement from './splitReactElement';
 
-export default element => {
+export default (element, type = 'start') => {
   if (React.isValidElement(element) && React.Children.count(element.props.children) === 0) {
-    return splitReactElement(element).start.length;
+    return splitReactElement(element)[type].length;
   }
 
   if (typeof element === 'object') {
-    return element.start ? element.start.length : 0;
+    return element[type] ? element[type].length : 0;
   }
 
   return 0;

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -12,34 +12,33 @@ export default function updateMutation(
   // the length, and mutations that occur partially within the new one.
   const lengthDiff = newLength - originalLength;
 
-  const mutationAfterChange = originalOffset + originalLength <=
-    mutation.offset;
+  const mutationAfterChange = originalOffset + originalLength <= mutation.offset;
   if (mutationAfterChange) {
     return Object.assign({}, mutation, {
       offset: mutation.offset + lengthDiff
     });
   }
 
-  const mutationContainsChange = originalOffset >= mutation.offset &&
-    originalOffset + originalLength <= mutation.offset + mutation.length;
+  const mutationContainsChange = originalOffset >= mutation.offset
+    && originalOffset + originalLength <= mutation.offset + mutation.length;
   if (mutationContainsChange) {
     return Object.assign({}, mutation, {
       length: mutation.length + lengthDiff
     });
   }
 
-  const mutationWithinPrefixChange = mutation.offset >= originalOffset &&
-    mutation.offset + mutation.length <= originalOffset + originalLength &&
-    prefixLength > 0;
+  const mutationWithinPrefixChange = mutation.offset >= originalOffset
+    && mutation.offset + mutation.length <= originalOffset + originalLength
+    && prefixLength > 0;
   if (mutationWithinPrefixChange) {
     return Object.assign({}, mutation, {
       offset: mutation.offset + prefixLength
     });
   }
 
-  const mutationContainsPrefix = mutation.offset < originalOffset &&
-    mutation.offset + mutation.length <= originalOffset + originalLength &&
-    prefixLength > 0;
+  const mutationContainsPrefix = mutation.offset < originalOffset
+    && mutation.offset + mutation.length <= originalOffset + originalLength
+    && prefixLength > 0;
   if (mutationContainsPrefix) {
     return [
       Object.assign({}, mutation, {
@@ -52,9 +51,9 @@ export default function updateMutation(
     ];
   }
 
-  const mutationContainsSuffix = mutation.offset >= originalOffset &&
-    mutation.offset + mutation.length > originalOffset + originalLength &&
-    suffixLength > 0;
+  const mutationContainsSuffix = mutation.offset >= originalOffset
+    && mutation.offset + mutation.length > originalOffset + originalLength
+    && suffixLength > 0;
   if (mutationContainsSuffix) {
     return [
       Object.assign({}, mutation, {
@@ -63,9 +62,9 @@ export default function updateMutation(
       }),
       Object.assign({}, mutation, {
         offset: originalOffset + originalLength + prefixLength + suffixLength,
-        length: mutation.offset +
-          mutation.length -
-          (originalOffset + originalLength)
+        length:
+          mutation.offset + mutation.length
+          - (originalOffset + originalLength)
       })
     ];
   }

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -574,7 +574,7 @@ describe('convertToHTML', () => {
       });
 
       const result = convertToHTML(convertToHTMLProps)(contentState);
-      expect(result).toBe('<p><strong>overlappin</strong><em><strong>g </strong><a href=\"http://google.com\"><strong>st</strong>yles</a> in en</em>tity</p>');
+      expect(result).toBe('<p><strong>overlappin</strong><em><strong>g </strong><a href="http://google.com"><strong>st</strong>yles</a> in en</em>tity</p>');
     });
   });
 


### PR DESCRIPTION
My stab at fixing #46.

Address styles that intersect with entities that have a prefix/suffix conversion strategy by splitting the style's mutation into two ranges - one inside the entity's tag, one outside. I also added some better naming to conditions in `updateMutation` to make it more readable.

Thanks to @liyantang for pushing the ball forward here and for the tests which I included in this PR. One of the ended up outputting a slightly different nesting order but I believe it should still be equivalent.