### PR TITLE
Omit blocks in convertFromHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ type EntityKey = string
 
 type convertFromHTML = HTMLConverter | ({
     htmlToStyle: ?(nodeName: string, node: Node) => DraftInlineStyle,
-    htmlToBlock: ?(nodeName: string, node: Node) => ?(DraftBlockType | {type: DraftBlockType, data: object}),
+    htmlToBlock: ?(nodeName: string, node: Node) => ?(DraftBlockType | {type: DraftBlockType, data: object} | false),
     htmlToEntity: ?(nodeName: string, node: string): ?EntityKey,
     textToEntity: ?(text) => Array<{entity: EntityKey, offset: number, length: number, result: ?string}>
 }) => HTMLConverter

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -349,9 +349,16 @@ function genFragment(
   }
 
   // Block Tags
-  const blockInfo = checkBlockType(nodeName, node, lastList, inBlock) || {};
+  let blockInfo = checkBlockType(nodeName, node, lastList, inBlock);
   let blockType;
   let blockDataMap;
+
+  if (blockInfo === false) {
+    return getEmptyChunk();
+  } else {
+    blockInfo = blockInfo || {};
+  }
+
   if (typeof blockInfo === 'string') {
     blockType = blockInfo;
     blockDataMap = Map();
@@ -432,29 +439,33 @@ function genFragment(
       && fragmentBlockTags.indexOf(nodeName) >= 0
       && inBlock
     ) {
-      const newBlockInfo = checkBlockType(nodeName, child, lastList, inBlock) || {};
+      let newBlockInfo = checkBlockType(nodeName, child, lastList, inBlock);
 
       let newBlockType;
       let newBlockData;
 
-      if (typeof newBlockInfo === 'string') {
-        newBlockType = newBlockInfo;
-        newBlockData = Map();
-      } else {
-        newBlockType = newBlockInfo.type || getBlockTypeForTag(nodeName, lastList);
-        newBlockData = newBlockInfo.data ? Map(newBlockInfo.data) : Map();
-      }
+      if (newBlockInfo !== false) {
+        newBlockInfo = newBlockInfo || {};
 
-      chunk = joinChunks(
-        chunk,
-        getSoftNewlineChunk(
-          newBlockType,
-          depth,
-          options.flat,
-          newBlockData
-        ),
-        options.flat
-      );
+        if (typeof newBlockInfo === 'string') {
+          newBlockType = newBlockInfo;
+          newBlockData = Map();
+        } else {
+          newBlockType = newBlockInfo.type || getBlockTypeForTag(nodeName, lastList);
+          newBlockData = newBlockInfo.data ? Map(newBlockInfo.data) : Map();
+        }
+
+        chunk = joinChunks(
+          chunk,
+          getSoftNewlineChunk(
+            newBlockType,
+            depth,
+            options.flat,
+            newBlockData
+          ),
+          options.flat
+        );
+      }
     }
     if (sibling) {
       nodeName = sibling.nodeName.toLowerCase();

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -355,9 +355,9 @@ function genFragment(
 
   if (blockInfo === false) {
     return getEmptyChunk();
-  } else {
-    blockInfo = blockInfo || {};
   }
+
+  blockInfo = blockInfo || {};
 
   if (typeof blockInfo === 'string') {
     blockType = blockInfo;

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -596,9 +596,9 @@ describe('convertFromHTML', () => {
           return false;
         }
       }
-    })(html, {flat: true});
+    })(html, { flat: true });
 
     expect(contentState.getBlocksAsArray().length).toBe(1);
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
-  })
+  });
 });

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -557,4 +557,48 @@ describe('convertFromHTML', () => {
     expect(blocks.slice(0, 2).every(block => block.getType() === 'unordered-list-item')).toBe(true);
     expect(blocks.slice(2, 4).every(block => block.getType() === 'ordered-list-item')).toBe(true);
   });
+
+  it('ignores blocks that return false in htmlToBlock', () => {
+    const html = '<div>test1</div><p>test2</p><div>test3</div>';
+
+    const contentState = convertFromHTML({
+      htmlToBlock: nodeName => {
+        if (nodeName === 'p') {
+          return false;
+        }
+      }
+    })(html);
+
+    expect(contentState.getBlocksAsArray().length).toBe(2);
+  });
+
+  it('ignores nested blocks that return false in htmlToBlock', () => {
+    const html = '<div>test1<p>test2</p></div>';
+
+    const contentState = convertFromHTML({
+      htmlToBlock: nodeName => {
+        if (nodeName === 'p') {
+          return false;
+        }
+      }
+    })(html);
+
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
+  });
+
+  it('ignores nested blocks that return false in htmlToBlock when flat is true', () => {
+    const html = '<div>test1<p>test2</p></div>';
+
+    const contentState = convertFromHTML({
+      htmlToBlock: nodeName => {
+        if (nodeName === 'p') {
+          return false;
+        }
+      }
+    })(html, {flat: true});
+
+    expect(contentState.getBlocksAsArray().length).toBe(1);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
+  })
 });


### PR DESCRIPTION
Addresses #58

Returning `false` in `htmlToBlock` will cause the node to get ignored entirely when building content state (including any contents).