### PR TITLE
Fix containing mutation

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -35,7 +35,7 @@ export default (block, entityMap, entityConverter = converter) => {
       const suffixLength = getElementTagLength(entityHTML, 'end');
 
       const updateLaterMutation = (mutation, mutationIndex) => {
-        if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
+        if (mutationIndex > index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
           return updateMutation(
             mutation, entityRange.offset, entityRange.length,
             converted.length, prefixLength, suffixLength

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -37,7 +37,8 @@ export default function updateMutation(
   }
 
   const mutationContainsPrefix = mutation.offset < originalOffset
-    && mutation.offset + mutation.length >= originalOffset + originalLength
+    && mutation.offset + mutation.length <= originalOffset + originalLength
+    && mutation.offset + mutation.length > originalOffset
     && prefixLength > 0;
   if (mutationContainsPrefix) {
     return [
@@ -53,6 +54,7 @@ export default function updateMutation(
 
   const mutationContainsSuffix = mutation.offset >= originalOffset
     && mutation.offset + mutation.length > originalOffset + originalLength
+    && originalOffset + originalLength > mutation.offset
     && suffixLength > 0;
   if (mutationContainsSuffix) {
     return [

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -37,7 +37,7 @@ export default function updateMutation(
   }
 
   const mutationContainsPrefix = mutation.offset < originalOffset
-    && mutation.offset + mutation.length <= originalOffset + originalLength
+    && mutation.offset + mutation.length >= originalOffset + originalLength
     && prefixLength > 0;
   if (mutationContainsPrefix) {
     return [

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -494,6 +494,59 @@ describe('convertToHTML', () => {
       expect(result).toBe('<p>overlapping <a href="http://google.com">st<strong>yles</strong></a><strong> in entity</strong></p>');
     });
 
+    it('correctly handles mutation containing another prefixed mutation', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping test Hello World',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 11,
+              style: 'BOLD'
+            },
+            {
+              offset: 23,
+              length: 5,
+              style: 'ITALIC'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 17,
+              length: 5,
+            },
+            {
+              key: 1,
+              offset: 23,
+              length: 5,
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        },
+        1: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p><strong>overlapping</strong> test <a href="http://google.com">Hello</a> <em><a href="http://google.com">World</a></em></p>');
+    });
+
+
     it('combines styles and entities when intersection with no style text to right and left', () => {
       const contentState = buildContentState([
         {


### PR DESCRIPTION
Fixes example from @liyantang in #66

- Stops updating mutations with themselves in `blockEntities`, since that now would create a different result
- Restrict conditions for overlapping with a prefix/suffix to be accurate