### PR TITLE
Added Nested Block support for "code-block"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist/
 lib/
 npm-debug.log
+.idea/

--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -17,7 +17,8 @@ import defaultBlockHTML from './default/defaultBlockHTML';
 
 const NESTED_BLOCK_TYPES = [
   'ordered-list-item',
-  'unordered-list-item'
+  'unordered-list-item' ,
+  'code-block'
 ];
 
 const defaultEntityToHTML = (entity, originalText) => {


### PR DESCRIPTION
Since code-blocks in DraftJS follow the following format, they should allow nesting:
&lt;pre&gt;
&lt;pre&gt;1st block...&lt;/pre&gt;
&lt;pre&gt;2nd block...&lt;/pre&gt;
&lt;/pre&gt;