### PR TITLE
use new Entity API

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,19 +109,19 @@ const contentState = convertFromHTML({
             return currentStyle;
         }
     },
-    htmlToEntity: (nodeName, node) => {
+    htmlToEntity: (nodeName, node, createEntity) => {
         if (nodeName === 'a') {
-            return Entity.create(
+            return createEntity(
                 'LINK',
                 'MUTABLE',
                 {url: node.href}
             )
         }
     },
-    textToEntity: (text) => {
+    textToEntity: (text, createEntity) => {
         const result = [];
         text.replace(/\@(\w+)/g, (match, name, offset) => {
-            const entityKey = Entity.create(
+            const entityKey = createEntity(
                 'AT-MENTION',
                 'IMMUTABLE',
                 {name}
@@ -164,8 +164,21 @@ type EntityKey = string
 type convertFromHTML = HTMLConverter | ({
     htmlToStyle: ?(nodeName: string, node: Node) => DraftInlineStyle,
     htmlToBlock: ?(nodeName: string, node: Node) => ?(DraftBlockType | {type: DraftBlockType, data: object} | false),
-    htmlToEntity: ?(nodeName: string, node: string): ?EntityKey,
-    textToEntity: ?(text) => Array<{entity: EntityKey, offset: number, length: number, result: ?string}>
+    htmlToEntity: ?(
+        nodeName: string,
+        node: string,
+        createEntity: (type: string, mutability: string, data: object) => EntityKey,
+        getEntity: (key: EntityKey) => Entity,
+        mergeEntityData: (key: string, data: object) => void,
+        replaceEntityData: (key: string, data: object) => void
+    ): ?EntityKey,
+    textToEntity: ?(
+        text: string,
+        createEntity: (type: string, mutability: string, data: object) => EntityKey,
+        getEntity: (key: EntityKey) => Entity,
+        mergeEntityData: (key: string, data: object) => void,
+        replaceEntityData: (key: string, data: object) => void
+    ) => Array<{entity: EntityKey, offset: number, length: number, result: ?string}>
 }) => HTMLConverter
 ```
 

--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -11,7 +11,7 @@
  */
 
 import { List, OrderedSet, Map } from 'immutable';
-import { ContentState, CharacterMetadata, ContentBlock, BlockMapBuilder, genKey } from 'draft-js';
+import { ContentState, CharacterMetadata, ContentBlock, Entity, BlockMapBuilder, genKey } from 'draft-js';
 import getSafeBodyFromHTML from './util/parseHTML';
 import rangeSort from './util/rangeSort';
 
@@ -640,8 +640,12 @@ const convertFromHTML = ({
 ) => {
   let contentState = ContentState.createFromText('');
   const createEntityWithContentState = (...args) => {
-    contentState = contentState.createEntity(...args);
-    return contentState.getLastCreatedEntityKey();
+    if (contentState.createEntity) {
+      contentState = contentState.createEntity(...args);
+      return contentState.getLastCreatedEntityKey();
+    }
+
+    return Entity.create(...args);
   };
 
 

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { convertToRaw, Entity } from 'draft-js';
+import { Entity, convertToRaw } from 'draft-js';
 import convertFromHTML from '../../src/convertFromHTML';
 import convertToHTML from '../../src/convertToHTML';
 

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Entity, convertToRaw } from 'draft-js';
+import { convertToRaw } from 'draft-js';
 import convertFromHTML from '../../src/convertFromHTML';
 import convertToHTML from '../../src/convertToHTML';
 

--- a/test/spec/convertFromHTML.js
+++ b/test/spec/convertFromHTML.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { convertToRaw } from 'draft-js';
+import { convertToRaw, Entity } from 'draft-js';
 import convertFromHTML from '../../src/convertFromHTML';
 import convertToHTML from '../../src/convertToHTML';
 
@@ -8,6 +8,15 @@ const customBlockToHTML = {
     start: '<p>',
     end: '</p>'
   }
+};
+
+const getEntity = (contentState, entityKey) => {
+  // compatibility shim for draft-js@0.10 entity changes
+  if (contentState.getEntity) {
+    return contentState.getEntity(entityKey);
+  }
+
+  return Entity.get(entityKey);
 };
 
 describe('convertFromHTML', () => {
@@ -345,7 +354,7 @@ describe('convertFromHTML', () => {
     expect(blocks[0].getType()).toBe('atomic');
     expect(blocks[0].characterList.size).toBe(1);
     const entityKey = blocks[0].characterList.first().entity;
-    const entity = contentState.getEntity(entityKey);
+    const entity = getEntity(contentState, entityKey);
     expect(entity.getType()).toBe('IMAGE');
     expect(entity.getData().src).toBe('test');
   });
@@ -356,7 +365,7 @@ describe('convertFromHTML', () => {
     const blocks = contentState.getBlocksAsArray();
     expect(blocks.length).toBe(3);
     expect(blocks[1].getType()).toBe('atomic');
-    expect(contentState.getEntity(blocks[1].getEntityAt(0)).getType()).toBe('IMAGE');
+    expect(getEntity(contentState, blocks[1].getEntityAt(0)).getType()).toBe('IMAGE');
     const resultHTML = convertToHTML({
       blockToHTML: {
         'atomic': {


### PR DESCRIPTION
Fixes #38 

First real pass at getting this working without using `Entity.create`. Essentially an empty`ContentState` is created before conversion begins, and a function is passed down to be called on the result of `textToEntity` or `htmlToEntity` to create an entity on that contentState. Those `*ToEntity` methods now return an object of shape `{type, mutability, data}`.

An alternative that I thought of while writing this was to instead pass that function as an additional argument to the`*ToEntity` functions themselves so that they can return with the string result of an `Entity.create`-like function like before. This would also make it easier for users to track down issues if there were an exception when creating the entity since it would be called from their own code at some point.