### PR TITLE
Fix overlapping entity conversion within React components

### DIFF
--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -5,7 +5,7 @@ const getElementTagLength = (element, type = 'start') => {
   if (React.isValidElement(element)) {
     const length = splitReactElement(element)[type].length;
 
-    const child = React.Children.toArray(element.props.children)[0];
+    const child = React.Children.only(element.props.children);
     return length + (child && React.isValidElement(child)
       ? getElementTagLength(child, type)
       : 0

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import splitReactElement from './splitReactElement';
 
-export default (element, type = 'start') => {
+const getElementTagLength = (element, type = 'start') => {
   if (React.isValidElement(element)) {
-    return splitReactElement(element)[type].length;
+    const length = splitReactElement(element)[type].length;
+
+    const child = React.Children.toArray(element.props.children)[0];
+    return length + (child && React.isValidElement(child)
+      ? getElementTagLength(child, type)
+      : 0
+    );
   }
 
   if (typeof element === 'object') {
@@ -12,3 +18,5 @@ export default (element, type = 'start') => {
 
   return 0;
 };
+
+export default getElementTagLength;

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -2,7 +2,7 @@ import React from 'react';
 import splitReactElement from './splitReactElement';
 
 export default (element, type = 'start') => {
-  if (React.isValidElement(element) && React.Children.count(element.props.children) === 0) {
+  if (React.isValidElement(element)) {
     return splitReactElement(element)[type].length;
   }
 

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -5,7 +5,7 @@ const getElementTagLength = (element, type = 'start') => {
   if (React.isValidElement(element)) {
     const length = splitReactElement(element)[type].length;
 
-    const child = React.Children.only(element.props.children);
+    const child = React.Children.toArray(element.props.children)[0];
     return length + (child && React.isValidElement(child)
       ? getElementTagLength(child, type)
       : 0

--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,5 +1,8 @@
 {
   "env": {
     "jasmine": true
+  },
+  "rules": {
+    "no-invalid-this": "off"
   }
 }

--- a/test/spec/blockEntities.js
+++ b/test/spec/blockEntities.js
@@ -540,4 +540,37 @@ describe('blockEntities', () => {
 
     expect(result).toBe('test <a>link</a>');
   });
+
+  it('correctly updates overlapping style ranges', () => {
+    const entityMap = {
+      0: {
+        type: 'LINK',
+        mutability: 'IMMUTABLE',
+        data: {}
+      }
+    };
+
+    const rawBlock = buildRawBlock(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      entityMap,
+      [{
+        offset: 22,
+        length: 34,
+        style: 'ITALIC'
+      }],
+      [{
+        offset: 0,
+        length: 26,
+        key: 0
+      }]
+    );
+
+    const updatedBlock = blockEntities(rawBlock, entityMap, (entity, originalText) => {
+      if (entity.type === 'LINK') {
+        return <a href="http://test.com">{originalText}</a>;
+      }
+    });
+
+    expect(updatedBlock.inlineStyleRanges.length).toBe(2);
+  });
 });

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -357,9 +357,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 0,
-              length: 28,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 28
             }
           ],
         },
@@ -399,9 +397,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 0,
-              length: 28,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 28
             }
           ],
         },
@@ -436,9 +432,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 12,
-              length: 6,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 6
             }
           ],
         },
@@ -473,9 +467,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 12,
-              length: 6,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 6
             }
           ],
         },
@@ -568,9 +560,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 12,
-              length: 6,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 6
             }
           ],
         },
@@ -610,9 +600,7 @@ describe('convertToHTML', () => {
             {
               key: 0,
               offset: 12,
-              length: 6,
-              prefixLength: '<a href="http://google.com">'.length,
-              suffixLength: '</a>'.length
+              length: 6
             }
           ],
         },
@@ -815,5 +803,45 @@ describe('convertToHTML', () => {
     })(contentState);
 
     expect(result).toBe(blockContents);
+  });
+
+  it('handles overlapping entity and style', () => {
+    const contentState = buildContentState([
+      {
+        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        type: 'unstyled',
+        entityRanges: [{
+          offset: 0,
+          length: 26,
+          key: 0
+        }],
+        styleRanges: [{
+          offset: 22,
+          length: 34,
+          style: 'ITALIC'
+        }]
+      }
+    ], {
+      0: {
+        type: 'LINK',
+        mutability: 'IMMUTABLE',
+        data: {}
+      }
+    });
+
+    const html = convertToHTML({
+      styleToHTML: (style) => {
+        if (style === 'ITALIC') {
+          return <i />;
+        }
+      },
+      entityToHTML: (entity, originalText) => {
+        if (entity.type === 'LINK') {
+          return <a href="http://test.com">{originalText}</a>;
+        }
+      }
+    })(contentState);
+
+    expect(html).toBe('<p><a href="http://test.com">Lorem ipsum dolor sit <i>amet</i></a><i>, consectetur adipiscing elit.</i></p>');
   });
 });

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -830,7 +830,7 @@ describe('convertToHTML', () => {
     });
 
     const html = convertToHTML({
-      styleToHTML: (style) => {
+      styleToHTML: style => {
         if (style === 'ITALIC') {
           return <i />;
         }

--- a/test/spec/updateMutation.js
+++ b/test/spec/updateMutation.js
@@ -1,0 +1,214 @@
+import updateMutation from '../../src/util/updateMutation';
+
+describe('updateMutation', function run() {
+  const prefix = '<a href="http://test.com">';
+  const suffix = '</a>';
+
+
+  describe('adjusts a mutation disjoint and subsequent to a changed mutation', () => {
+    beforeAll(() => {
+      const firstMutation = {
+        offset: 1,
+        length: 20,
+        key: 0
+      };
+
+      const secondMutation = {
+        offset: 24,
+        length: 5,
+        style: 'ITALIC'
+      };
+
+      this.updatedMutation = updateMutation(
+        secondMutation,
+        firstMutation.offset,
+        firstMutation.length,
+        firstMutation.length + prefix.length + suffix.length,
+        prefix.length,
+        suffix.length
+      );
+    });
+
+    it('does not split the updated mutation', () => {
+      expect(Array.isArray(this.updateMutation)).toBe(false);
+    });
+
+    it('moves the mutation to the correct point', () => {
+      expect(this.updatedMutation).toEqual({
+        offset: 54,
+        length: 5,
+        style: 'ITALIC'
+      });
+    });
+  });
+
+  describe('adjusts a mutation completely containing a changed mutation', () => {
+    beforeAll(() => {
+      const firstMutation = {
+        offset: 5,
+        length: 20,
+        key: 0
+      };
+
+      const secondMutation = {
+        offset: 2,
+        length: 25,
+        style: 'ITALIC'
+      };
+
+      this.updatedMutation = updateMutation(
+        secondMutation,
+        firstMutation.offset,
+        firstMutation.length,
+        firstMutation.length + prefix.length + suffix.length,
+        prefix.length,
+        suffix.length
+      );
+    });
+
+    it('does not split the updated mutation', () => {
+      expect(Array.isArray(this.updateMutation)).toBe(false);
+    });
+
+    it('increases the mutation length to the correct size', () => {
+      expect(this.updatedMutation).toEqual({
+        offset: 2,
+        length: 55,
+        style: 'ITALIC'
+      });
+    });
+  });
+
+  describe('adjusts a mutation within a changed mutation with a nonzero prefix', () => {
+    beforeAll(() => {
+      const firstMutation = {
+        offset: 2,
+        length: 20,
+        key: 0
+      };
+
+      const secondMutation = {
+        offset: 5,
+        length: 10,
+        style: 'ITALIC'
+      };
+
+      this.updatedMutation = updateMutation(
+        secondMutation,
+        firstMutation.offset,
+        firstMutation.length,
+        firstMutation.length + prefix.length + suffix.length,
+        prefix.length,
+        suffix.length
+      );
+    });
+
+    it('does not split the updated mutation', () => {
+      expect(Array.isArray(this.updateMutation)).toBe(false);
+    });
+
+    it('moves the mutation to the correct point', () => {
+      expect(this.updatedMutation).toEqual({
+        offset: 31,
+        length: 10,
+        style: 'ITALIC'
+      });
+    });
+  });
+
+  describe('adjusts for overlap of later mutation with prefix', () => {
+    beforeAll(() => {
+      const firstMutation = {
+        offset: 1,
+        length: 20,
+        key: 0
+      };
+
+      const secondMutation = {
+        offset: 0,
+        length: 12,
+        style: 'ITALIC'
+      };
+
+      this.updatedMutation = updateMutation(
+        secondMutation,
+        firstMutation.offset,
+        firstMutation.length,
+        firstMutation.length + prefix.length + suffix.length,
+        prefix.length,
+        suffix.length
+      );
+    });
+
+    it('splits the updated mutation into two', () => {
+      expect(Array.isArray(this.updatedMutation)).toBe(true);
+      expect(this.updatedMutation.length).toBe(2);
+    });
+
+    it('splits the mutation at the correct point', () => {
+      const [
+        firstUpdatedMutation,
+        secondUpdatedMutation
+      ] = this.updatedMutation;
+
+      expect(firstUpdatedMutation).toEqual({
+        offset: 0,
+        length: 1,
+        style: 'ITALIC'
+      });
+      expect(secondUpdatedMutation).toEqual({
+        offset: 27,
+        length: 11,
+        style: 'ITALIC'
+      });
+    });
+  });
+
+  describe('adjusts for overlap of later mutation with suffix', () => {
+    beforeAll(() => {
+      const firstMutation = {
+        offset: 0,
+        length: 26,
+        key: 0
+      };
+
+      const secondMutation = {
+        offset: 22,
+        length: 34,
+        style: 'ITALIC'
+      };
+
+      this.updatedMutation = updateMutation(
+        secondMutation,
+        firstMutation.offset,
+        firstMutation.length,
+        firstMutation.length + prefix.length + suffix.length,
+        prefix.length,
+        suffix.length
+      );
+    });
+
+    it('splits the later mutation into two', () => {
+      expect(Array.isArray(this.updatedMutation)).toBe(true);
+      expect(this.updatedMutation.length).toBe(2);
+    });
+
+    it('splits the mutation at the correct point', () => {
+      const [
+        firstUpdatedMutation,
+        secondUpdatedMutation
+      ] = this.updatedMutation;
+
+      expect(firstUpdatedMutation).toEqual({
+        offset: 48,
+        length: 4,
+        style: 'ITALIC'
+      });
+      expect(secondUpdatedMutation).toEqual({
+        offset: 56,
+        length: 30,
+        style: 'ITALIC'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #76 

Adding @ryanscottaudio's changes here so that they can get out ASAP. The only real change was using `React.Children.only` instead of `React.Children.toArray`, which I think will be more useful to someone who was confused by the behavior if they were passing multiple sibling children.

I added some tests that cover a couple levels of the problem that were useful to diagnose the problem along the way, including a set of tests for each case of `updateMutation`.

Thanks @ryanscottaudio for identifying the problem and scoping out the solution!