### PR TITLE
Fix double escaping of entities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "immutable": "~3.7.4",
-    "invariant": "^2.2.1"
+    "invariant": "^2.2.1",
+    "lodash.unescape": "^4.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/src/util/getElementHTML.js
+++ b/src/util/getElementHTML.js
@@ -1,6 +1,7 @@
 import invariant from 'invariant';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import unescape from 'lodash.unescape';
 import splitReactElement from './splitReactElement';
 
 function hasChildren(element) {
@@ -18,7 +19,11 @@ export default function getElementHTML(element, text = null) {
 
   if (React.isValidElement(element)) {
     if (hasChildren(element)) {
-      return ReactDOMServer.renderToStaticMarkup(element);
+      // `renderToStaticMarkup` will escape HTML entities. However,
+      // these are already escaped at this point, so this will cause
+      // them to be escaped twice. As there's no way to turn off the HTML
+      // escaping of React, the resulting HTML needs to be unescaped once.
+      return unescape(ReactDOMServer.renderToStaticMarkup(element));
     }
 
     const tags = splitReactElement(element);

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -289,6 +289,47 @@ describe('convertToHTML', () => {
     expect(result).toBe('<p>t<a>e&lt;&amp;&gt;s</a><strong>t</strong></p>');
   });
 
+  it('escapes HTML in text of entities only once', () => {
+    const contentState = buildContentState([
+      {
+        type: 'unstyled',
+        text: 'Led Zeppelin - Since I\'ve Been Loving You',
+        entityRanges: [{ key: 0, offset: 0, length: 41 }]
+      }
+    ], { 0: { type: 'LINK', mutability: 'IMMUTABLE' } });
+
+    const result = convertToHTML({ entityToHTML: (entity, originalText) => {
+      if (entity.type === 'LINK') {
+        return <a>{originalText}</a>;
+      }
+      return originalText;
+    } })(contentState);
+    expect(result)
+      .toBe('<p><a>Led Zeppelin - Since I&#x27;ve Been Loving You</a></p>');
+  });
+
+  it('escapes HTML in text of entities only once when using a custom component', () => {
+    const contentState = buildContentState([
+      {
+        type: 'unstyled',
+        text: 'Led Zeppelin - Since I\'ve Been Loving You',
+        entityRanges: [{ key: 0, offset: 0, length: 41 }]
+      }
+    ], { 0: { type: 'LINK', mutability: 'IMMUTABLE' } });
+
+    // eslint-disable-next-line react/prop-types
+    const Link = ({ children }) => <a>{children}</a>;
+
+    const result = convertToHTML({ entityToHTML: (entity, originalText) => {
+      if (entity.type === 'LINK') {
+        return <Link>{originalText}</Link>;
+      }
+      return originalText;
+    } })(contentState);
+    expect(result)
+      .toBe('<p><a>Led Zeppelin - Since I&#x27;ve Been Loving You</a></p>');
+  });
+
   it('uses block metadata', () => {
     const contentState = buildContentState([
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,6 +2717,10 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash.unescape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
 lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
Fixes #47.

The double escaping occurs, because there's a [call to `encodeBlock` at the beginning](https://github.com/HubSpot/draft-convert/blob/0313264e882f0984b63ef6f569f50636a94b6b1d/src/convertToHTML.js#L87) followed by a [call to `renderToStaticMarkup`](https://github.com/HubSpot/draft-convert/blob/0313264e882f0984b63ef6f569f50636a94b6b1d/src/util/getElementHTML.js#L21
) if a element is provided that has children.

So basically there are two options to fix this:
 
1. Only escape text that is not passed to to a `renderToStaticMarkup` call.
2. Unescape the resulting markup from `renderToStaticMarkup`.

To me the first option would have been a bit cleaner, but surfaced some issues for me:
 - I thought about calling `encodeBlock` in `getElementHTML`, but since `getElementHTML` is only used for entities and inline styles, this would lead to regular blocks not being escaped.
 - It's not possible to escape after creating entities and inline styles, as those functions create HTML tags which shouldn't be encoded.
 - The only way for React to render unescaped content is `dangerouslySetInnerHTML`, however as we don't have HTML but a React element this is not possible here.

So a proper way to go with the first option might have led to a bigger change to the code base which I wanted to avoid. Therefore I went for the second option, which seems to work pretty well. The unescape helper is pretty small (1.2K minified, non-gzipped) so I hope this is ok for you.

I encountered this bug recently, so I thought I'll provide a fix for it. Let me know what you think! 🙂