### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const contentState = convertFromHTML({
     },
     textToEntity: (text, createEntity) => {
         const result = [];
-        text.replace(/\@(\w+)/g, (match, name, offset) => {
+        text.replace(/\@(\w+)/g, (match, offset, name) => {
             const entityKey = createEntity(
                 'AT-MENTION',
                 'IMMUTABLE',


### PR DESCRIPTION
Advanced usage example of textToEntity  was wrong.
When using `replace` method in `textToEntity`, the order of replace arguments was wrong.
It should be  `text.replace(/\@(\w+)/g, (match, offset, name) => {`