### PR TITLE
fix void elements in entityToHTML

### DIFF
--- a/src/util/getElementHTML.js
+++ b/src/util/getElementHTML.js
@@ -23,7 +23,7 @@ export default function getElementHTML(element, text = null) {
 
     const tags = splitReactElement(element);
 
-    if (text !== null) {
+    if (text !== null && typeof tags === 'object') {
       const { start, end } = tags;
       return start + text + end;
     }

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -3,7 +3,12 @@ import splitReactElement from './splitReactElement';
 
 const getElementTagLength = (element, type = 'start') => {
   if (React.isValidElement(element)) {
-    const length = splitReactElement(element)[type].length;
+    const splitElement = splitReactElement(element);
+    if (typeof splitElement === 'string') {
+      return 0;
+    }
+
+    const length = splitElement[type].length;
 
     const child = React.Children.toArray(element.props.children)[0];
     return length + (child && React.isValidElement(child)

--- a/test/spec/blockEntities-test.js
+++ b/test/spec/blockEntities-test.js
@@ -573,4 +573,33 @@ describe('blockEntities', () => {
 
     expect(updatedBlock.inlineStyleRanges.length).toBe(2);
   });
+
+  it('allows void react elements as conversion results for entities', () => {
+    const entityMap = {
+      0: {
+        type: 'IMAGE',
+        mutability: 'IMMUTABLE',
+        data: {}
+      }
+    };
+
+    const rawBlock = buildRawBlock(
+      ' ',
+      entityMap,
+      null,
+      [{
+        offset: 0,
+        length: 1,
+        key: 0
+      }]
+    );
+
+    const result = blockEntities(rawBlock, entityMap, (entity, originalText) => {
+      if (entity.type === 'IMAGE') {
+        return <img src="test" />;
+      }
+    });
+
+    expect(result.text).toBe('<img src="test"/>');
+  });
 });


### PR DESCRIPTION
fixes #101 

I think this was an issue I ran into when trying to integrate flow, but it never made it to master. There were a couple places that didn't expect anything except a `{ start, end }` object from `splitReactElement`.