### PR TITLE
Custom nested block types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "rimraf ./dist && rimraf ./lib",
     "build-and-test": "npm run clean && npm run build && npm run test-once",
     "lint": "eslint src/ test/",
+    "prepare": "npm run build-and-test",
     "prepublish": "npm run lint && npm run build-and-test"
   },
   "files": [

--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -15,11 +15,6 @@ import getNestedBlockTags from './util/getNestedBlockTags';
 
 import defaultBlockHTML from './default/defaultBlockHTML';
 
-const NESTED_BLOCK_TYPES = [
-  'ordered-list-item',
-  'unordered-list-item'
-];
-
 const defaultEntityToHTML = (entity, originalText) => {
   return originalText;
 };
@@ -57,7 +52,7 @@ const convertToHTML = ({
     let closeNestTags = '';
     let openNestTags = '';
 
-    if (NESTED_BLOCK_TYPES.indexOf(type) === -1) {
+    if (!getBlockHTML(block).nest) {
       // this block can't be nested, so reset all nesting if necessary
       closeNestTags = listStack.reduceRight((string, nestedBlock) => {
         return string + getNestedBlockTags(getBlockHTML(nestedBlock)).nestEnd;

--- a/test/spec/convertToHTML-test.js
+++ b/test/spec/convertToHTML-test.js
@@ -619,6 +619,38 @@ describe('convertToHTML', () => {
     });
   });
 
+  it('allows specifying custom nested block types', () => {
+    const convertToHTMLProps = {
+      blockToHTML: block => {
+        if (block.type === 'checkable-list-item') {
+          return {
+            element: <li data-checked={block.data.checked || false} />,
+            nest: <ul />
+          };
+        }
+      }
+    };
+
+    const contentState = buildContentState([
+      {
+        type: 'checkable-list-item',
+        text: 'item one',
+        data: {
+          checked: false
+        }
+      },
+      {
+        type: 'checkable-list-item',
+        text: 'item two',
+        data: {
+          checked: true
+        }
+      }
+    ]);
+    const result = convertToHTML(convertToHTMLProps)(contentState);
+    expect(result).toBe('<ul><li data-checked="false">item one</li><li data-checked="true">item two</li></ul>');
+  });
+
   it('combines styles and entities without overlap using react to convert to HTML', () => {
     const contentState = buildContentState([
       {


### PR DESCRIPTION
Currently nested block types are specified as a constant:

```javascript
const NESTED_BLOCK_TYPES = [
  'ordered-list-item',
  'unordered-list-item'
];
```

This makes it difficult to render nested HTML for custom nested block types like the https://github.com/sugarshin/draft-js-checkable-list-plugin.

Given that this nesting information is already stored in the default block mapping file:

```javascript
export default {
  ...,
  'unordered-list-item': {
    element: <li />,
    nest: <ul />
  },
  'ordered-list-item': {
    element: <li />,
    nest: <ol />
  },
  ...
}
```

...we can get rid of the constant and allow providing custom nested block mapping like so:

```javascript
export const contentStateToHtml = convertToHTML({
  blockToHTML: (block) => {
    if (block.type === 'checkable-list-item') {
      return {
        element: <li data-checked={block.data.checked || false} />,
        nest: <ul />
      }
    }
  }
}
```

I added a test example to illustrate the expected behavior.