### PR TITLE
Handle void tags like <img /> correctly

### DIFF
--- a/src/util/getElementHTML.js
+++ b/src/util/getElementHTML.js
@@ -25,6 +25,10 @@ export default function getElementHTML(element, text = null) {
 
     if (text !== null) {
       const { start, end } = tags;
+      if (!start && !end) {
+        // This is a void tag
+        return tags;
+      }
       return start + text + end;
     }
 

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -3,7 +3,7 @@ import splitReactElement from './splitReactElement';
 
 const getElementTagLength = (element, type = 'start') => {
   if (React.isValidElement(element)) {
-    const length = splitReactElement(element)[type].length;
+    const length = (splitReactElement(element)[type] || splitReactElement(element)).length;
 
     const child = React.Children.toArray(element.props.children)[0];
     return length + (child && React.isValidElement(child)

--- a/test/spec/blockEntities-test.js
+++ b/test/spec/blockEntities-test.js
@@ -406,7 +406,7 @@ describe('blockEntities', () => {
     expect(result).toBe('test <a>link</a>');
   });
 
-  it.only('handles a void ReactElement in entityToHTML', () => {
+  it('handles a void ReactElement in entityToHTML', () => {
     const entityMap = {
       0: {
         type: 'test',

--- a/test/spec/blockEntities-test.js
+++ b/test/spec/blockEntities-test.js
@@ -406,6 +406,49 @@ describe('blockEntities', () => {
     expect(result).toBe('test <a>link</a>');
   });
 
+  it.only('handles a void ReactElement in entityToHTML', () => {
+    const entityMap = {
+      0: {
+        type: 'test',
+        mutability: 'IMMUTABLE',
+        data: {
+          test: 'test'
+        }
+      }
+    };
+
+    const rawBlock = buildRawBlock(
+      'test img',
+      entityMap,
+      [],
+      [
+        {
+          key: 0,
+          offset: 5,
+          length: 4
+        }
+      ]
+    );
+
+    const result = blockInlineStyles(
+      blockEntities(
+        encodeBlock(
+          rawBlock
+        ),
+        entityMap,
+        (entity, originalText) => {
+          if (entity.type === 'test') {
+            return <img src="test" />;
+          }
+
+          return originalText;
+        }
+      )
+    );
+
+    expect(result).toBe('test <img src="test"/>');
+  });
+
   it('handles a ReactElement with a child in entityToHTML', () => {
     const entityMap = {
       0: {


### PR DESCRIPTION
Hi! Thanks for a great project! I ran into trouble when trying to use an `<img />` tag with `entityToHTML`. I updated the code to account for results from `splitReactElement` that aren't an array, and added a test case.

Thanks!