### PR TITLE
Ensure correct block keys in selectionState after conversion from HTML

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -11,7 +11,7 @@
  */
 
 import { List, OrderedSet, Map } from 'immutable';
-import { ContentState, CharacterMetadata, ContentBlock, Entity, BlockMapBuilder, genKey } from 'draft-js';
+import { ContentState, CharacterMetadata, ContentBlock, Entity, BlockMapBuilder, genKey, SelectionState } from 'draft-js';
 import getSafeBodyFromHTML from './util/parseHTML';
 import rangeSort from './util/rangeSort';
 
@@ -714,7 +714,12 @@ const convertFromHTML = ({
   );
 
   const blockMap = BlockMapBuilder.createFromArray(contentBlocks);
-  return contentState.set('blockMap', blockMap);
+  const firstBlockKey = contentBlocks[0].getKey();
+  return contentState.merge({
+    blockMap: blockMap,
+    selectionBefore: SelectionState.createEmpty(firstBlockKey),
+    selectionAfter: SelectionState.createEmpty(firstBlockKey)
+  });
 };
 
 export default (...args) => {

--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -609,4 +609,22 @@ describe('convertFromHTML', () => {
     expect(contentState.getBlocksAsArray().length).toBe(1);
     expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
   });
+
+  it("maintains the correct block key for selectionBefore and selectionAfter", () => {
+    const htmlChunks = ['<p>one<br/><br/>two</p>', '<div>test1<p>test2</p></div>', ''];
+
+    htmlChunks.forEach((html) => {
+      const contentState = convertFromHTML({
+        htmlToBlock: nodeName => {
+          if (nodeName === 'p') {
+            return false;
+          }
+        }
+      })(html, { flat: true });
+
+      expect(contentState.getFirstBlock().getKey()).toBe(contentState.getSelectionBefore().getStartKey());
+      expect(contentState.getFirstBlock().getKey()).toBe(contentState.getSelectionAfter().getStartKey());
+    });
+  });
+
 });


### PR DESCRIPTION
When converting HTML to a ContentBlock, we start with an empty block to
get a starting ContentState object. However, the starting block is
overwritten when we set the 'blockMap' based on the blocks created from
the HTML. At this point, the 'selectionBefore' and 'selectionAfter'
properties of the ContentBlock still reference the original block's key
which is no longer valid. This change ensures that we correctly set the
keys in 'selectionBefore' and 'selectionAfter' to match the first block
of the ContentState. There's also a test added to check this case.