### PR TITLE
Increase visual accuracy of convertFromHTML flat mode

### DIFF
--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -111,9 +111,9 @@ describe('convertFromHTML', () => {
       },
       entityToHTML: (entity, originalText) => {
         if (entity.type === 'TEST') {
-          return `<testnode test-attr="${
-            entity.data.testAttr
-          }">${originalText}</testnode>`;
+          return `<testnode test-attr="${entity.data.testAttr}">${
+            originalText
+          }</testnode>`;
         } else if (entity.type === 'AT-MENTION') {
           return `@${entity.data.name}`;
         } else if (entity.type === 'MERGE-TAG') {
@@ -683,5 +683,23 @@ describe('convertFromHTML', () => {
         contentState.getSelectionAfter().getStartKey()
       );
     });
+  });
+
+  it('splits block with text and block element as siblings when flat is true', () => {
+    const html = '<div>test1<p>test2</p></div>';
+
+    const contentState = convertFromHTML(html, { flat: true });
+
+    expect(contentState.getBlocksAsArray().length).toBe(2);
+    expect(contentState.getBlocksAsArray()[0].getText()).toBe('test1');
+  });
+
+  it('does not add an extra empty line at the end when a block with deep lines ends with brs', () => {
+    const html =
+      '<div>third line<div>deep line</div><div>2 deep line</div><br><br></div><div>fourth line</div></div>';
+
+    const contentState = convertFromHTML(html, { flat: true });
+
+    expect(contentState.getBlocksAsArray().length).toBe(6);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/HubSpot/draft-convert/issues/113

Adds two fixes to `flat: true` mode of `convertToHTML`:
1) If in flat mode within a block starting with text as a direct child and a sibling element to that text is identified as a block, add a block divider of its type.
2) If a non-empty block has a `<br>` tag as a last child, don't add the closing block separator to the chunk.