### PR TITLE
Copy arrays before sorting them

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -20,7 +20,7 @@ export default (block, entityMap, entityConverter = converter) => {
     Object.prototype.hasOwnProperty.call(block, 'entityRanges') &&
     block.entityRanges.length > 0
   ) {
-    let entities = block.entityRanges.sort(rangeSort);
+    let entities = [...block.entityRanges].sort(rangeSort);
 
     let styles = block.inlineStyleRanges;
 

--- a/src/blockInlineStyles.js
+++ b/src/blockInlineStyles.js
@@ -93,7 +93,7 @@ export default (rawBlock, customInlineHTML = defaultCustomInlineHTML) => {
   let result = '';
   let styleStack = [];
 
-  const sortedRanges = rawBlock.inlineStyleRanges.sort(rangeSort);
+  const sortedRanges = [...rawBlock.inlineStyleRanges].sort(rangeSort);
 
   const originalTextArray = [...rawBlock.text];
 

--- a/src/encodeBlock.js
+++ b/src/encodeBlock.js
@@ -14,8 +14,8 @@ const ENTITY_MAP = {
 export default block => {
   const blockText = [...block.text];
 
-  let entities = block.entityRanges.sort(rangeSort);
-  let styles = block.inlineStyleRanges.sort(rangeSort);
+  let entities = [...block.entityRanges].sort(rangeSort);
+  let styles = [...block.inlineStyleRanges].sort(rangeSort);
   let resultText = '';
 
   for (let index = 0; index < blockText.length; index++) {


### PR DESCRIPTION
We're running into an issue using react-apollo where it marks its data structures as read only. Since `sort()` returns as well as mutates the array (even if there are no changes to order), the Apollo cache raises exceptions.

This change copies all the in-place arrays that sort operates on (leaving out the one instance of `sort` that proceeds a `concatt`). Since sort is being run on each function call, the behavior does not need to depend on the in-place mutation, and should act the same.