### PR TITLE
add default blockToHTML value for atomic blocks

### DIFF
--- a/src/default/defaultBlockHTML.js
+++ b/src/default/defaultBlockHTML.js
@@ -19,4 +19,5 @@ export default {
     nest: <ol />,
   },
   media: <figure />,
+  atomic: <figure />,
 };


### PR DESCRIPTION
This has come up a couple times in #130 and #129 so I thought I'd might as well add it as a default value.