### PR TITLE
add more useful error message when unable to convert a block

### DIFF
--- a/src/convertToHTML.js
+++ b/src/convertToHTML.js
@@ -50,7 +50,16 @@ const convertToHTML = ({
       let closeNestTags = '';
       let openNestTags = '';
 
-      if (!getBlockHTML(block).nest) {
+      const blockHTMLResult = getBlockHTML(block);
+      if (!blockHTMLResult) {
+        throw new Error(
+          `convertToHTML: missing HTML definition for block with type ${
+            block.type
+          }`
+        );
+      }
+
+      if (!blockHTMLResult.nest) {
         // this block can't be nested, so reset all nesting if necessary
         closeNestTags = listStack.reduceRight((string, nestedBlock) => {
           return string + getNestedBlockTags(getBlockHTML(nestedBlock)).nestEnd;

--- a/test/spec/convertToHTML-test.js
+++ b/test/spec/convertToHTML-test.js
@@ -1053,4 +1053,17 @@ describe('convertToHTML', () => {
       '<p>👍 <br/><a href="https://www.google.com">Santi Albo</a></p>'
     );
   });
+
+  it('throws a meaningful error when no block definition exists', () => {
+    const contentState = buildContentState([
+      {
+        type: 'test',
+        text: 'asdf',
+      },
+    ]);
+
+    expect(() => convertToHTML(contentState)).toThrowError(
+      /missing HTML definition/
+    );
+  });
 });


### PR DESCRIPTION
This should hopefully prevent confusion like in #129 and #130 - the error will now explain what happened and what the block type was. It should also make it easier to debug further since there will be a check and specific `throw` line to add a breakpoint on instead of going through every `getBlockHTML` call