### PR TITLE
Process heavily nested divs properly 

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -307,6 +307,9 @@ function genFragment(
     }
 
     if (text.trim() === '' && inBlock !== 'code-block') {
+      if (options.flatNestedDivs) {
+        return getEmptyChunk();
+      }
       return getWhitespaceChunk(inEntity);
     }
     if (inBlock !== 'code-block') {
@@ -501,11 +504,18 @@ function genFragment(
           newBlockData = newBlockInfo.data ? Map(newBlockInfo.data) : Map();
         }
 
-        chunk = joinChunks(
-          chunk,
-          getSoftNewlineChunk(newBlockType, depth, options.flat, newBlockData),
-          options.flat
-        );
+        const text = sibling.textContent;
+        const shouldAddEmptyChunk =
+          options.flatNestedDivs && text.trim() === '' && text.includes('\n');
+        const anotherChunk = shouldAddEmptyChunk
+          ? getEmptyChunk()
+          : getSoftNewlineChunk(
+              newBlockType,
+              depth,
+              options.flat,
+              newBlockData
+            );
+        chunk = joinChunks(chunk, anotherChunk, options.flat);
       }
     }
     if (sibling) {
@@ -681,6 +691,7 @@ const convertFromHTML = ({
   html,
   options = {
     flat: false,
+    flatNestedDivs: false,
   },
   DOMBuilder = getSafeBodyFromHTML,
   generateKey = genKey

--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -684,4 +684,35 @@ describe('convertFromHTML', () => {
       );
     });
   });
+
+  it('handles heavily nested divs', () => {
+    const text = 'Best regards';
+    const html = `<div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>
+    <div>${text}</div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    </div>`;
+    const contentState = toContentState(html, { flatNestedDivs: true });
+    expect(contentState.getBlockMap().size).toEqual(1);
+
+    const firstBlock = contentState.getFirstBlock();
+    expect(firstBlock.getText()).toEqual(text);
+    expect(firstBlock.getType()).toEqual('unstyled');
+  });
 });


### PR DESCRIPTION
In out app, we have weird behaviour for processing heavily nested divs(see screenshot). For each single one of the the opening tag is converted into a whitespace, and the closing one is converted to the linebreak. This PR add a new option `flatNestedDivs` to handle this case properly.

![screen shot 2018-10-09 at 17 31 20](https://user-images.githubusercontent.com/8644623/46677621-aae9c400-cbeb-11e8-8a4a-7d1ddc1d4506.png)
