### PR TITLE
Add support of font-weight: 700 converting to BOLD

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -203,7 +203,10 @@ function processInlineTag(tag, node, currentStyle) {
     const htmlElement = node;
     currentStyle = currentStyle
       .withMutations(style => {
-        if (htmlElement.style.fontWeight === 'bold') {
+        if (
+          htmlElement.style.fontWeight === 'bold' ||
+          htmlElement.style.fontWeight === '700'
+        ) {
           style.add('BOLD');
         }
 

--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -178,6 +178,14 @@ describe('convertFromHTML', () => {
     testFixture(html);
   });
 
+  it('converts font-weight: 700 to bold style', () => {
+    const html = '<p><span style="font-weight:700;">test</span></p>';
+    const contentState = toContentState(html);
+    const styles = contentState.getFirstBlock().getInlineStyleAt(0);
+    expect(styles.size).toBe(1);
+    expect(styles.has('BOLD')).toBe(true);
+  });
+
   it('ul - nested', () => {
     const htmlFixture = `
       <ul>


### PR DESCRIPTION
In our app we work with pasting text from different source: Gmail, Google Docs, Word etc.
And in some on these sources bold text is handled with `font-weight: 700` rather than with `bold` value.