### PR TITLE
Stop resetting `inlineStyles` in `baseProcessInlineTag`

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -224,8 +224,8 @@ function processInlineTag(tag, node, currentStyle) {
   return currentStyle;
 }
 
-function baseProcessInlineTag(tag, node) {
-  return processInlineTag(tag, node, OrderedSet());
+function baseProcessInlineTag(tag, node, inlineStyles = OrderedSet()) {
+  return processInlineTag(tag, node, inlineStyles);
 }
 
 function joinChunks(A, B, flat = false) {

--- a/test/spec/convertFromHTML-test.js
+++ b/test/spec/convertFromHTML-test.js
@@ -141,6 +141,18 @@ describe('convertFromHTML', () => {
     testFixture('<p><strong>draft<u>JS</u></strong></p>');
   });
 
+  it('nested inline styles - with naive middleware htmlToStyle', () => {
+    const htmlIn = '<p><strong><u>Boo</u></strong></p>';
+    const defaultMiddlewareFunction = next => (...args) => next(...args);
+    defaultMiddlewareFunction.__isMiddleware = true;
+
+    const contentState = convertFromHTML({
+      htmlToStyle: defaultMiddlewareFunction,
+    })(htmlIn);
+    const htmlOut = convertToHTML(contentState);
+    expect(htmlOut).toEqual(htmlIn);
+  });
+
   it('empty paragraphs', () => {
     const htmlFixture = '<p>one</p><p></p><p>two</p>';
     const state = convertFromHTML(htmlFixture);


### PR DESCRIPTION
This was preventing more than one inline style from surviving a `convertToHTML` -> `convertFromHTML` round trip.