### PR TITLE
Add esm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist/
 lib/
+esm/
 npm-debug.log
 .DS_Store

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,10 @@
 module.exports = {
   presets: ['@babel/env', '@babel/react'],
+  plugins: ['@babel/transform-runtime'],
+  env: {
+    esm: {
+      presets: [['@babel/env', { modules: false }]],
+      plugins: [['@babel/transform-runtime', { useESModules: true }]]
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -3,17 +3,19 @@
   "version": "2.1.7",
   "description": "Extensibly serialize & deserialize Draft.js ContentState",
   "main": "lib/index.js",
+  "module": "esm/index.js",
   "repository": "HubSpot/draft-convert",
   "scripts": {
-    "build": "npm run build:commonjs && npm run build:umd",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:umd",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --out-dir esm",
     "build:umd": "wp",
     "jest": "jest",
     "jest:watch": "jest --watch",
     "jest:debug": "node --debug-brk --inspect ./node_modules/.bin/jest -i",
     "test-once": "npm run jest",
     "test": "npm run jest",
-    "clean": "rimraf ./dist && rimraf ./lib",
+    "clean": "rimraf ./dist ./lib ./esm",
     "build-and-test": "npm run clean && npm run build && npm run test-once",
     "lint": "eslint src/ test/",
     "prepare": "npm run build-and-test",
@@ -22,7 +24,8 @@
   },
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "esm"
   ],
   "keywords": [
     "draft",
@@ -38,12 +41,14 @@
     "react-dom": "^15.0.2|| ^16.0.0-rc || ^16.0.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "immutable": "~3.7.4",
     "invariant": "^2.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.4",
+    "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,6 +567,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz#a6331afbfc59189d2135b2e09474457a8e3d28bc"
+  integrity sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -679,6 +689,13 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+
+"@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
@@ -4847,6 +4864,11 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
 regenerator-transform@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.0.tgz#2ca9aaf7a2c239dd32e4761218425b8c7a86ecaf"
@@ -4990,7 +5012,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.3.2, resolve@^1.9.0:
+resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==


### PR DESCRIPTION
This is useful for bundlers like rollup which does not handle commonjs
out of the box.

Babel runtime allows to share helpers with other projects and save some bytes.

/cc @benbriggs @maxwellskala 