### PR TITLE
stop publishing eval source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = [
   {
     ...baseConfig,
     mode: 'development',
+    devtool: 'none',
     output: {
       filename: 'draft-convert.js',
       library,


### PR DESCRIPTION
I realized that in 2.1.7 we started to bundle `eval()` source maps in the UMD bundle due to the WebPack 4 upgrade from #146. You could see them here: https://unpkg.com/draft-convert@2.1.7/dist/draft-convert.js. 



