### PR TITLE
fix UMD commonjs configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,11 +11,30 @@ const baseConfig = {
     ],
   },
   externals: {
-    'draft-js': 'Draft',
-    immutable: 'Immutable',
-    react: 'React',
-    'react-dom': 'ReactDOM',
-    'react-dom/server': 'ReactDOMServer',
+    'draft-js': {
+      commonjs: 'draft-js',
+      commonjs2: 'draft-js',
+      amd: 'draft-js',
+      root: 'Draft'
+    },
+    immutable:  {
+      commonjs: 'immutable',
+      commonjs2: 'immutable',
+      amd: 'immutable',
+      root: 'Immutable'
+    },
+    react:  {
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
+      root: 'React'
+    },
+    'react-dom/server': {
+      commonjs: 'react-dom/server',
+      commonjs2: 'react-dom/server',
+      amd: 'react-dom/server',
+      root: 'ReactDOMServer'
+    },
   },
 };
 


### PR DESCRIPTION
I noticed in our existing UMD bundle the module names won't work in a normal commonjs environment:
From https://unpkg.com/draft-convert@2.1.8/dist/draft-convert.js
```
module.exports = factory(require("Draft"), require("Immutable"), require("React"), require("ReactDOMServer"));
```
Notice that the module names are innacurate and should be:
```
module.exports = factory(require("draft-js"), require("immutable"), require("react"), require("react-dom/server"));
```

I'm assuming that nobody is actually using this UMD bundle except for us and we weren't using it as commonjs so it should be save in a patch release?
