### PR TITLE
Stop replacing empty string returns from entityToHTML with originalText

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -33,9 +33,13 @@ export default (block, entityMap, entityConverter = converter) => {
         .join('');
 
       const entityHTML = getEntityHTML(entity, originalText);
-      const converted = [
-        ...(getElementHTML(entityHTML, originalText) || originalText),
-      ];
+      const elementHTML = getElementHTML(entityHTML, originalText);
+      let converted;
+      if (!!elementHTML || elementHTML === '') {
+        converted = [...elementHTML];
+      } else {
+        converted = originalText;
+      }
 
       const prefixLength = getElementTagLength(entityHTML, 'start');
       const suffixLength = getElementTagLength(entityHTML, 'end');

--- a/test/spec/blockEntities-test.js
+++ b/test/spec/blockEntities-test.js
@@ -438,6 +438,52 @@ describe('blockEntities', () => {
     expect(result).toBe('test <a>test</a>');
   });
 
+  it('handles an empty string in entityToHTML', () => {
+    const entityMap = {
+      0: {
+        type: 'test',
+        mutability: 'IMMUTABLE',
+        data: {
+          test: 'test',
+        },
+      },
+    };
+
+    const rawText = 'test link';
+    const offset = 5;
+    const length = 4;
+    const rawBlock = buildRawBlock(
+      rawText,
+      entityMap,
+      [],
+      [
+        {
+          key: 0,
+          offset,
+          length,
+        },
+      ]
+    );
+
+    const result = blockInlineStyles(
+      blockEntities(
+        encodeBlock(rawBlock),
+        entityMap,
+        (entity, originalText) => {
+          if (entity.type === 'test') {
+            return '';
+          }
+
+          return originalText;
+        }
+      )
+    );
+
+    const entitySubstring = rawText.slice(5, offset + length);
+    const expected = rawText.replace(entitySubstring, '');
+    expect(result).toBe(expected);
+  });
+
   it('handles a start/end object in entityToHTML', () => {
     const entityMap = {
       0: {


### PR DESCRIPTION
`getElementHTML` can return both `undefined` and `null`, in which case `blockEntities` should replace that "html" with `originalText`. However, the existing check for this case was also replacing `''`, since it is falsy, meaing `'' || originalText` resolved to `originalText`.

Before this change, it was impossible to fully strip entity text when converting to HTML without including dummy tags with dummy children (e.g. `<span>{''}</span>`).