### PR TITLE
Default blockToHTML values for article and section

### DIFF
--- a/src/default/defaultBlockHTML.js
+++ b/src/default/defaultBlockHTML.js
@@ -26,4 +26,6 @@ export default {
   },
   media: <figure />,
   atomic: <figure />,
+  article: <article />,
+  section: <section />,
 };


### PR DESCRIPTION
`draft-js` already has support for article and section blocks (https://github.com/facebook/draft-js/pull/2212). Due to the lack of support for these blocks from `draft-convert`, this results in an error:
```
convertToHTML: missing HTML definition for block with type section.
```

![image](https://user-images.githubusercontent.com/30337614/113862308-d1980e00-97da-11eb-9a54-a52eda7d37e9.png)
