### PR TITLE
add default block HTML for code-block type

### DIFF
--- a/src/default/defaultBlockHTML.js
+++ b/src/default/defaultBlockHTML.js
@@ -12,6 +12,7 @@ export default {
   'header-four': <h4 />,
   'header-five': <h5 />,
   'header-six': <h6 />,
+  'code-block': <pre />,
   blockquote: <blockquote />,
   'unordered-list-item': {
     element: <li />,

--- a/test/spec/convertToHTML-test.js
+++ b/test/spec/convertToHTML-test.js
@@ -110,6 +110,17 @@ describe('convertToHTML', () => {
     expect(result).toBe('<p>test paragraph</p>');
   });
 
+  it('applies code block styles', () => {
+    const contentState = buildContentState([
+      {
+        type: 'code-block',
+        text: 'test code block',
+      },
+    ]);
+    const result = convertToHTML(contentState);
+    expect(result).toBe('<pre>test code block</pre>');
+  });
+
   it('applies style to multiple blocks', () => {
     const contentState = buildContentState([
       {


### PR DESCRIPTION
resolves https://github.com/HubSpot/draft-convert/issues/182

note this default behavior will wrap adjacent `code-block`s in separate `<pre>` tags and not try to do anything fancy in terms of combining blocks or the text in the block