### PR TITLE
[+] convertFromHtml span with whitespace

### DIFF
--- a/src/convertFromHTML.js
+++ b/src/convertFromHTML.js
@@ -371,6 +371,16 @@ function genFragment(
   inlineStyle = processInlineTag(nodeName, node, inlineStyle);
   inlineStyle = processCustomInlineStyles(nodeName, node, inlineStyle);
 
+  if (nodeName === 'span' && (node.textContent === SPACE || node.textContent === NBSP || node.textContent === '\s')) {
+    let text = node.textContent
+    return {
+      text,
+      inlines: Array(text.length).fill(inlineStyle),
+      entities: Array(text.length).fill(inEntity),
+      blocks: [],
+    }
+  }
+
   // Handle lists
   if (nodeName === 'ul' || nodeName === 'ol') {
     if (lastList) {


### PR DESCRIPTION
Hi, i have a bug similar to this #177.
And I noticed that when copying and pasting in the editor, the text with inlineStyles is glued into one line without spaces.
This code solved my problem. Please, check him.
